### PR TITLE
Minor improvements to directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
-build
+# Build directory
+build/
+
+# Private files (i.e. for client-specific initialization scripts)
+private/
+
+# Visual Studio code settings
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ private/
 
 # Visual Studio code settings
 .vscode/
+
+# Modelsim files
+work/
+transcript
+
+# Ctags
+tags


### PR DESCRIPTION
Add common files to exclude from remote synchronization to `gitignore`. These include:
- A `private/` directory where to put client- or user- specific files and scritps (e.g., local environment initialization scripts)
- Visual Studio Code workspace settings and data (`.vscode`)
- Modelsim automatically-generated files and directories
- Ctags (or Universal Ctags) cache directory