### PR TITLE
[FIX] Correction of memory map

### DIFF
--- a/hw/packages/gr_heep_pkg.sv.tpl
+++ b/hw/packages/gr_heep_pkg.sv.tpl
@@ -93,7 +93,7 @@ package gr_heep_pkg;
     localparam int unsigned ${a_slave['name']}PeriphIdx = 32'd${a_slave['idx']};
     localparam logic [31:0] ${a_slave['name']}PeriphStartAddr = EXT_PERIPHERAL_START_ADDRESS + 32'h${a_slave['offset']};
     localparam logic [31:0] ${a_slave['name']}PeriphSize = 32'h${a_slave['size']};
-    localparam logic [31:0] ${a_slave['name']}PeriphEndAddr = ${a_slave['name']}StartAddr + 32'h${a_slave['size']};
+    localparam logic [31:0] ${a_slave['name']}PeriphEndAddr = ${a_slave['name']}PeriphStartAddr + 32'h${a_slave['size']};
 % endfor
     
         // External peripherals address map


### PR DESCRIPTION
Corrected the memory map: in line 96, the name StartAddr was mistakenly used instead of PeriphStartAddr.